### PR TITLE
v1.09

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,9 @@
+1.09	2017-02-15
+		- Object::Exception::dump_trace() indentation fix
+		- Object::Exception msg attribute calling as method
+		- Added $tracelevel in Object::Exception::throw()
+		- $msg arg of Object::Exception::throw() can be as a object of child class Object::Exception
+
 1.08	2017-02-12
 		- Added traceback, dump_trace functions in Object::Exception
 		- Attribute modifiers don't work with ':shared' feature

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -5,7 +5,7 @@ use ExtUtils::MakeMaker;
 
 WriteMakefile(
 	NAME				=> 'Object::Base',
-	VERSION				=> '1.08',
+	VERSION				=> '1.09',
 	MIN_PERL_VERSION	=> '5.008',
 	PREREQ_PM			=> {
 		'threads'		=> '1.72',

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -10,7 +10,8 @@ WriteMakefile(
 	PREREQ_PM			=> {
 		'threads'		=> '1.72',
 		'threads::shared' => '1.28',
-		'forks'		=> '0.29',
+		'forks'			=> '0.29',
+		'SUPER'			=> '1.20141117',
 	},
 	EXE_FILES			=> [qw(
 	)],

--- a/README
+++ b/README
@@ -153,6 +153,8 @@ DEPENDENCIES
 
     *   forks
 
+    *   SUPER
+
 REPOSITORY
     GitHub <https://github.com/orkunkaraduman/p5-Object-Base>
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ This module requires these other modules and libraries:
 - threads
 - threads::shared
 - forks
+- SUPER
 
 # REPOSITORY
 

--- a/README.pod
+++ b/README.pod
@@ -164,6 +164,10 @@ threads::shared
 
 forks
 
+=item *
+
+SUPER
+
 =back
 
 =head1 REPOSITORY

--- a/lib/Object/Base.pm
+++ b/lib/Object/Base.pm
@@ -128,6 +128,14 @@ Inheritable
 
 Overridable
 
+=item *
+
+Redefinable
+
+=item *
+
+Not thread-safe
+
 =back
 
 =head3 Modifiers
@@ -488,6 +496,16 @@ __END__
 B<GitHub> L<https://github.com/orkunkaraduman/p5-Object-Base>
 
 B<CPAN> L<https://metacpan.org/release/Object-Base>
+
+=head1 SEE ALSO
+
+=over
+
+=item *
+
+L<Object::Exception|https://metacpan.org/pod/Object::Exception>
+
+=back
 
 =head1 AUTHOR
 

--- a/lib/Object/Exception.pm
+++ b/lib/Object/Exception.pm
@@ -137,6 +137,7 @@ sub throw
 	if (ref($msg))
 	{
 		return unless UNIVERSAL::isa($msg, __PACKAGE__);
+		$class = ref($msg) if $class eq __PACKAGE__;
 		unshift @trace, @{$msg->trace};
 		$msg = $msg->msg;
 	}

--- a/lib/Object/Exception.pm
+++ b/lib/Object/Exception.pm
@@ -69,11 +69,7 @@ BEGIN
 }
 
 
-attributes qw(:shared msg debug), 
-	trace => {
-		default => [],
-	}
-;
+attributes qw(:shared msg debug trace);
 
 
 sub new

--- a/lib/Object/Exception.pm
+++ b/lib/Object/Exception.pm
@@ -105,10 +105,10 @@ sub dump_trace
 {
 	my @trace = @_;
 	my $result = "";
-	my $i = 0;
+	my $i = 1;
 	for my $trace (reverse @trace)
 	{
-		$result .= sprintf("%-".((++$i)*2)."s", "");
+		$result .= sprintf("%-".($i*1)."s", "");
 		$result .= "in $trace->{package} ";
 		$result .= "at ";
 		$result .= "$trace->{subroutine} " if defined($trace->{subroutine});

--- a/lib/Object/Exception.pm
+++ b/lib/Object/Exception.pm
@@ -120,6 +120,7 @@ sub dump_trace
 	{
 		$i++;
 	}
+	chomp($result);
 	return $result;
 }
 
@@ -148,9 +149,9 @@ sub message
 	$debug = $self->debug unless defined($debug);
 	my $msg = $self->msg;
 	my $result = "";
-	$result .= "$msg\n" if defined($msg) and not ref($msg);
+	$result .= "$msg" if defined($msg) and not ref($msg);
 	return $result unless $debug;
-	$result .= dump_trace(@{$self->trace});
+	$result .= "\n".dump_trace(@{$self->trace});
 	return $result;
 }
 

--- a/lib/Object/Exception.pm
+++ b/lib/Object/Exception.pm
@@ -86,7 +86,7 @@ sub new
 sub traceback
 {
 	my ($i) = @_;
-	$i = 0 unless defined($i);
+	$i = 0 unless defined($i) and $i >= 0;
 	my @result;
 	while (scalar(my @caller = caller($i++)))
 	{
@@ -131,7 +131,7 @@ sub throw
 	{
 		$class = __PACKAGE__;
 	}
-	my ($msg) = @_;
+	my ($msg, $tracelevel) = @_;
 	return unless defined($class) and not ref($class) and UNIVERSAL::isa($class, __PACKAGE__);
 	my @trace;
 	if (ref($msg))
@@ -142,7 +142,9 @@ sub throw
 		$msg = $msg->msg;
 	}
 	my $self = $class->new($msg);
-	my @traceback = traceback(1);
+	$tracelevel = 0 unless defined($tracelevel);
+	$tracelevel++;
+	my @traceback = traceback($tracelevel);
 	unless (@trace)
 	{
 		unshift @trace, @traceback;

--- a/lib/Object/Exception.pm
+++ b/lib/Object/Exception.pm
@@ -5,7 +5,7 @@ Object::Exception - Multi-threaded base exception class
 
 =head1 VERSION
 
-version 1.08
+version 1.09
 
 =head1 ABSTRACT
 

--- a/lib/Object/Exception.pm
+++ b/lib/Object/Exception.pm
@@ -77,7 +77,7 @@ sub new
 	my $class = shift;
 	my ($msg) = @_;
 	my $self = $class->SUPER();
-	$self->msg = $msg;
+	$self->msg($msg);
 	$self->debug = (defined($main::DEBUG) and $main::DEBUG)? 1: 0;
 	$self->trace([]);
 	return $self;

--- a/lib/Object/Exception.pm
+++ b/lib/Object/Exception.pm
@@ -178,6 +178,16 @@ B<GitHub> L<https://github.com/orkunkaraduman/p5-Object-Base>
 
 B<CPAN> L<https://metacpan.org/release/Object-Base>
 
+=head1 SEE ALSO
+
+=over
+
+=item *
+
+L<Object::Base|https://metacpan.org/pod/Object::Base>
+
+=back
+
 =head1 AUTHOR
 
 Orkun Karaduman <orkunkaraduman@gmail.com>

--- a/t/Object-Base.t
+++ b/t/Object-Base.t
@@ -1,10 +1,11 @@
 use strict;
 use warnings;
 
-use Test::More tests => 1;
+use Test::More tests => 2;
 
 
 BEGIN
 {
 	require_ok('Object::Base');
+	use_ok('Object::Exception');
 }


### PR DESCRIPTION
- Object::Exception::dump_trace() indentation fix
- Object::Exception msg attribute calling as method
- Added $tracelevel in Object::Exception::throw()
- $msg arg of Object::Exception::throw() can be as a object of child class Object::Exception